### PR TITLE
docs: fix README version framing, npm badge, and Node requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sentio API
 
-[![npm version](https://badge.fury.io/js/@sentio%2Fapi.svg)](https://npmjs.com/package/@sentio/api) [![Release](https://github.com/sentioxyz/api/actions/workflows/cut-release.yaml/badge.svg)](https://github.com/sentioxyz/api/actions/workflows/cut-release.yaml)
+[![npm version](https://img.shields.io/npm/v/@sentio/api.svg)](https://www.npmjs.com/package/@sentio/api) [![Release](https://github.com/sentioxyz/api/actions/workflows/cut-release.yaml/badge.svg)](https://github.com/sentioxyz/api/actions/workflows/cut-release.yaml)
 
 TypeScript client for the [Sentio](https://sentio.xyz) API. The bindings are
 generated from Sentio's protobuf definitions with
@@ -10,10 +10,10 @@ through [connect-es](https://github.com/connectrpc/connect-es) with the
 transport — fully typed requests and responses, including server-streaming
 endpoints.
 
-> **v3 is a breaking rewrite.** v2 (`openapi-ts` based: `client.setConfig` +
+> **v2 is a breaking rewrite.** v1 (`openapi-ts` based: `client.setConfig` +
 > static service classes) is replaced by connect-es style clients. The REST
 > API itself is unchanged; see the examples below for the new shapes. The
-> package is ESM-only and requires Node 20+.
+> package is ESM-only and requires Node 24+.
 
 ## Setup
 


### PR DESCRIPTION
## What

Three doc-only corrections to `README.md`, verified against the npm registry and `package.json`:

| Issue | Before | After |
|---|---|---|
| **Version framing** | "**v3** is a breaking rewrite … **v2** (`openapi-ts` based)" | "**v2** is a breaking rewrite … **v1** (`openapi-ts` based)" |
| **npm badge** | `badge.fury.io` (deprecated/flaky) | `img.shields.io/npm/v/@sentio/api` |
| **Node requirement** | "requires Node **20+**" | "requires Node **24+**" |

## Why

- npm `latest` is **`2.0.0`** — the connect-es / protobuf-es rewrite (deps `@bufbuild/protobuf` + `@connectrpc/connect` + `@sentio/connect-gateway-es`). The openapi-ts client it replaced was the **`1.x`** line (`1.0.4` depended on `@hey-api/client-fetch`). The README's "v3 replaces v2" framing was off-by-one and would mislead anyone who runs `npm install @sentio/api` and gets 2.0.0.
- `badge.fury.io` is effectively unmaintained; shields.io is the standard, reliably-cached source and links to the canonical `www.npmjs.com` package page.
- `package.json` `engines` requires `node >=24` (and `CLAUDE.md` says Node 24+); the README said 20+.

## Notes for reviewer

- `README.md` is hand-written (not CI-owned `src/gen`), so this is safe to edit here.
- Code examples were spot-checked against the actual exports (`createSentioClient`/`WebService`/`InsightsService` and the `@sentio/api/gen/...` deep-import for `Project`) — all resolve; no example changes needed.
- `docs:` type does not trigger a semantic-release publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)