### PR TITLE
fix: ship dist in the published package (broken brace glob in files)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "./gen/*": "./dist/src/gen/*"
   },
   "files": [
-    "{dist,src}",
+    "dist",
+    "src",
     "!dist/test"
   ],
   "sideEffects": false,


### PR DESCRIPTION
## What

Split the `files` field's `"{dist,src}"` brace pattern into explicit `"dist"` and `"src"` entries.

```diff
   "files": [
-    "{dist,src}",
+    "dist",
+    "src",
     "!dist/test"
   ],
```

## Why

Published 2.x tarballs on npm contained only `LICENSE`, `package.json`, and `README.md` — **no `dist` or `src`** — so the package was effectively unusable when installed.

Root cause: the `files` field has always used the `"{dist,src}"` brace-expansion glob (since 1.x). **pnpm 9** (which published the working 1.x releases) expanded the brace; **pnpm 10/11** no longer does, so the pattern matched nothing and both directories were silently dropped from the tarball.

The latent bug surfaced in the 2.0 rewrite (e88441c), which bumped `packageManager` to `pnpm@11.3.0` and `pnpm/action-setup` to v6. The `files` field itself was not changed — only the pnpm version.

## Verification

`pnpm pack --dry-run` now includes all `dist/src/**` files and still correctly excludes `dist/test`.

## Reviewer notes

- This is a `chore`/`fix`-level change; merging to `main` will publish a fixed `rc` prerelease. Recommend confirming the `rc` tarball contains `dist` before cutting `latest` via the Cut Release workflow.
- All previously published 2.x versions on npm are affected and should be considered broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)