### PR TITLE
fix(client): default to api.sentio.xyz and strip the /api path prefix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,11 +42,14 @@ approval in `pnpm-workspace.yaml` (`allowBuilds: esbuild`).
   speaking the gateway REST dialect; `apiKey` is sent as the `api-key` header.
   `createSentioClient(Service, options)` is the one-service shortcut; for
   several services create one transport and use connect's `createClient`.
-- Default `baseUrl` is `https://app.sentio.xyz`, which serves the annotation
-  paths (`/api/v1/...`) verbatim. `https://api.sentio.xyz` serves the same API
-  under `/v1/...` (the prefix-stripped form used in the REST docs and
-  `openapi.json`) and will NOT route the annotation paths — don't point the
-  transport at it.
+- Default `baseUrl` is `https://api.sentio.xyz`, which serves the API under the
+  prefix-stripped `/v1/...` paths (the form used in the REST docs and
+  `openapi.json`). The generated descriptors carry the gateway's `/api/v1/...`
+  annotation paths, so `createSentioTransport` wraps `fetch` to drop the leading
+  `/api` segment before the request goes out (every public binding is
+  `/api/v1/*`). The legacy `https://app.sentio.xyz` origin served the
+  `/api/v1/...` paths verbatim and is being deprecated; pointing `baseUrl` at it
+  no longer routes, since the client now emits `/v1/...`.
 - protobuf-es conventions apply: request messages are partial init shapes
   (omitted fields take proto defaults), `oneof` fields are `{ case, value }`
   discriminated unions, errors are connect-es `ConnectError`s carrying the

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ import type { Project } from "@sentio/api/gen/service/common/protos/common_pb.js
 `createSentioClient` / `createSentioTransport` accept:
 
 - `apiKey` — sent as the `api-key` header.
-- `baseUrl` — defaults to `https://app.sentio.xyz`.
+- `baseUrl` — defaults to `https://api.sentio.xyz`.
 - everything else from `GatewayTransportOptions`
   (`headers`, `fetch`, `interceptors`, `defaultTimeoutMs`, ...).
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,11 +3,13 @@ import { type Client, createClient, type Transport } from '@connectrpc/connect'
 import { createGatewayTransport, type GatewayTransportOptions } from '@sentio/connect-gateway-es'
 
 /**
- * Default API origin. The generated bindings carry the gateway's `/api/v1/...`
- * paths, which this host serves directly (the same dialect the Sentio web app
- * and the sentio-sdk CLI use).
+ * Default API origin. `api.sentio.xyz` serves the API under the prefix-stripped
+ * `/v1/...` paths (the same surface documented in `openapi.json` and the REST
+ * reference). The legacy `https://app.sentio.xyz/api/v1/...` origin is being
+ * deprecated; see {@link createSentioTransport} for the path rewrite that lets
+ * the generated `/api/v1/...` bindings reach this host.
  */
-export const DEFAULT_BASE_URL = 'https://app.sentio.xyz'
+export const DEFAULT_BASE_URL = 'https://api.sentio.xyz'
 
 export interface SentioApiOptions extends Omit<GatewayTransportOptions, 'baseUrl'> {
   /**
@@ -20,18 +22,44 @@ export interface SentioApiOptions extends Omit<GatewayTransportOptions, 'baseUrl
 }
 
 /**
+ * Drops the gateway's historical `/api` path prefix from an outgoing request.
+ * The CI-generated descriptors carry the `/api/v1/...` annotation paths that the
+ * legacy `app.sentio.xyz` host served verbatim, but `api.sentio.xyz` exposes the
+ * same RPCs under `/v1/...`. Every binding in the public surface is `/api/v1/*`,
+ * so removing a leading `/api` segment yields the path the current host routes.
+ */
+function stripGatewayPathPrefix(
+  input: Parameters<typeof globalThis.fetch>[0],
+): Parameters<typeof globalThis.fetch>[0] {
+  if (typeof input !== 'string') return input
+  try {
+    const url = new URL(input)
+    if (url.pathname.startsWith('/api/v1/')) {
+      url.pathname = url.pathname.slice('/api'.length)
+      return url.toString()
+    }
+    return input
+  } catch {
+    // Relative URL (baseUrl: '', e.g. behind a same-origin proxy).
+    return input.startsWith('/api/v1/') ? input.slice('/api'.length) : input
+  }
+}
+
+/**
  * Creates a Connect transport that speaks Sentio's REST (grpc-gateway)
  * dialect. Share one transport across clients of multiple services.
  */
 export function createSentioTransport(options: SentioApiOptions = {}): Transport {
-  const { apiKey, baseUrl, headers, ...rest } = options
+  const { apiKey, baseUrl, headers, fetch: customFetch, ...rest } = options
   const h = new Headers(headers)
   if (apiKey !== undefined && !h.has('api-key')) {
     h.set('api-key', apiKey)
   }
+  const baseFetch = customFetch ?? globalThis.fetch
   return createGatewayTransport({
     baseUrl: baseUrl ?? DEFAULT_BASE_URL,
     headers: h,
+    fetch: (input, init) => baseFetch(stripGatewayPathPrefix(input), init),
     ...rest,
   })
 }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -63,13 +63,13 @@ test('an explicit api-key header is not overridden by apiKey', async () => {
   assert.equal(req.headers.get('api-key'), 'explicit')
 })
 
-test('defaults to the app.sentio.xyz origin', async () => {
+test('defaults to the api.sentio.xyz origin', async () => {
   const req = await callWith({ apiKey: 'k' })
   assert.ok(
     req.url.startsWith(DEFAULT_BASE_URL + '/'),
     `expected ${req.url} to start with ${DEFAULT_BASE_URL}`,
   )
-  assert.equal(DEFAULT_BASE_URL, 'https://app.sentio.xyz')
+  assert.equal(DEFAULT_BASE_URL, 'https://api.sentio.xyz')
 })
 
 test('a custom baseUrl is used and its trailing slash trimmed', async () => {
@@ -81,10 +81,11 @@ test('a custom baseUrl is used and its trailing slash trimmed', async () => {
   assert.ok(!req.url.startsWith('https://api-test.sentio.xyz//'), 'trailing slash not trimmed')
 })
 
-test('listCoins routes to GET /api/v1/prices/coins', async () => {
+test('listCoins routes to GET /v1/prices/coins (the /api prefix is stripped)', async () => {
   const req = await callWith({ apiKey: 'k' })
   assert.equal(req.method, 'GET')
-  assert.match(req.url, /\/api\/v1\/prices\/coins/)
+  assert.equal(req.url, 'https://api.sentio.xyz/v1/prices/coins')
+  assert.doesNotMatch(req.url, /\/api\/v1\//, 'the legacy /api prefix must not be sent')
 })
 
 test('one transport is shared across multiple service clients', async () => {


### PR DESCRIPTION
## What

Point the default API origin at **`api.sentio.xyz`** and strip the gateway's `/api` path prefix so requests hit the host's `/v1/...` surface.

- `DEFAULT_BASE_URL`: `https://app.sentio.xyz` → `https://api.sentio.xyz`
- `createSentioTransport` wraps `fetch` to drop a leading `/api` segment (`/api/v1/...` → `/v1/...`)
- Docs (`README.md`, `CLAUDE.md`) and tests updated

## Why

`https://app.sentio.xyz/api/v1/...` is being deprecated. The new host `api.sentio.xyz` serves the same API under the prefix-stripped `/v1/...` paths (the form already documented in `openapi.json` and the REST reference).

The catch: the CI-generated descriptors in `src/gen/**` (never hand-editable) carry the gateway's `/api/v1/...` annotation paths, and the transport has no path-rewrite option — it sends `baseUrl + path` verbatim. So a naive host swap produces `api.sentio.xyz/api/v1/...` → **404**. The `/api` prefix therefore has to be stripped at the transport layer, which `createSentioTransport` does by wrapping `fetch`.

Verified against the live hosts:

| Host | Path | Result |
|---|---|---|
| `api.sentio.xyz` | `/v1/prices/coins` | **200** |
| `api.sentio.xyz` | `/api/v1/prices/coins` | 404 |
| `app.sentio.xyz` | `/api/v1/prices/coins` | 200 (legacy, deprecated) |

All **75** bindings in the public surface (primary + every `additional_binding`, confirmed via `resolveGatewayRoute`) are `/api/v1/*` — zero `/api/v2` or other prefixes reach the client — so stripping a leading `/api` is universally correct.

## Verification

- `tsc` clean; all 8 offline tests pass (route test now asserts `https://api.sentio.xyz/v1/prices/coins`)
- End-to-end call through the real client (`PriceService.listCoins`, public) returned coins from `api.sentio.xyz` — a wrong path would have thrown `ConnectError`

## Reviewer notes

- **Behavior change for explicit legacy overrides:** the `/api` strip is unconditional, so a caller passing `baseUrl: 'https://app.sentio.xyz'` now gets `app.sentio.xyz/v1/...` → 404. Default users transparently migrate to the non-deprecated host. If we want a transition-period escape hatch (opt-out flag to keep the legacy host reachable), I can add one.
- **Release impact:** lands as a `fix` → patch `rc` prerelease on merge to `main`. If we'd rather treat the legacy-override change as breaking, we can adjust the commit/footer.
