### PR TITLE
chore(deps): bump @bufbuild/protobuf and CI action versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: 'pnpm'

--- a/.github/workflows/cut-release.yaml
+++ b/.github/workflows/cut-release.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
           ref: ${{ github.event.inputs.commit }}
       - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: 'pnpm'
@@ -37,7 +37,7 @@ jobs:
         run: pnpm install
       - name: Semantic Release
         id: semantic
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@v6
         with:
           semantic_version: 25.0.5
         env:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prepare": "pnpm build"
   },
   "dependencies": {
-    "@bufbuild/protobuf": "^2.12.0",
+    "@bufbuild/protobuf": "^2.12.1",
     "@connectrpc/connect": "^2.1.2",
     "@sentio/connect-gateway-es": "^1.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     dependencies:
       '@bufbuild/protobuf':
-        specifier: ^2.12.0
-        version: 2.12.0
+        specifier: ^2.12.1
+        version: 2.12.1
       '@connectrpc/connect':
         specifier: ^2.1.2
-        version: 2.1.2(@bufbuild/protobuf@2.12.0)
+        version: 2.1.2(@bufbuild/protobuf@2.12.1)
       '@sentio/connect-gateway-es':
         specifier: ^1.0.0
-        version: 1.0.0(@bufbuild/protobuf@2.12.0)(@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.12.0))
+        version: 1.0.0(@bufbuild/protobuf@2.12.1)(@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.12.1))
     devDependencies:
       '@types/node':
         specifier: ^24.13.2
@@ -71,8 +71,8 @@ packages:
     resolution: {integrity: sha512-2YnuOp4HAk2BsBrJJvYCbItHx0zWscI1C3zgWkz+wDyD9I7GIVrfnLyrR4Y1VR+7p+chAEcrgRQYZAGIKMV7vQ==}
     engines: {node: '>=6.9.0'}
 
-  '@bufbuild/protobuf@2.12.0':
-    resolution: {integrity: sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==}
+  '@bufbuild/protobuf@2.12.1':
+    resolution: {integrity: sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -1726,14 +1726,14 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.0.1
 
-  '@bufbuild/protobuf@2.12.0': {}
+  '@bufbuild/protobuf@2.12.1': {}
 
   '@colors/colors@1.5.0':
     optional: true
 
-  '@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.12.0)':
+  '@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.12.1)':
     dependencies:
-      '@bufbuild/protobuf': 2.12.0
+      '@bufbuild/protobuf': 2.12.1
 
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
@@ -1960,10 +1960,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sentio/connect-gateway-es@1.0.0(@bufbuild/protobuf@2.12.0)(@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.12.0))':
+  '@sentio/connect-gateway-es@1.0.0(@bufbuild/protobuf@2.12.1)(@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.12.1))':
     dependencies:
-      '@bufbuild/protobuf': 2.12.0
-      '@connectrpc/connect': 2.1.2(@bufbuild/protobuf@2.12.0)
+      '@bufbuild/protobuf': 2.12.1
+      '@connectrpc/connect': 2.1.2(@bufbuild/protobuf@2.12.1)
 
   '@sindresorhus/is@4.6.0': {}
 


### PR DESCRIPTION
## What

Upgrade the dependencies that have newer releases, plus the GitHub Actions used in CI/publish.

### npm
- `@bufbuild/protobuf` `^2.12.0` → `^2.12.1` (patch; `@connectrpc/connect` and `@sentio/connect-gateway-es` peer resolutions updated to match in the lockfile)

### GitHub Actions
- `actions/checkout` v4 → **v7**
- `actions/setup-node` v4 → **v6**
- `cycjimmy/semantic-release-action` v4 → **v6**
- `pnpm/action-setup` left at `@v6` (already the latest major via the floating tag)

## Why / notes for reviewers

Everything else is already at npm-latest (`@connectrpc/connect` 2.1.2, `@sentio/connect-gateway-es` 1.0.0, `semantic-release` 25.0.5, `tsx`, `typescript` 6.0.3, `json`). Per request, **`@types/node` (24) and `conventional-changelog-conventionalcommits` (9) were intentionally left as-is** even though majors exist (26 and 10).

Action major bumps were checked against their release notes:
- **checkout v5+** and **setup-node v5+** move to a Node 24 runtime (requires runner ≥ 2.327.1, which `ubuntu-latest` provides).
- **setup-node v5/v6** changed *automatic* package-manager cache detection, but these workflows set `cache: 'pnpm'` explicitly (and `pnpm/action-setup` still runs before `setup-node`), so caching behavior is unchanged.
- **semantic-release-action v6** defaults its bundled semantic-release to v25, which matches the already-pinned `semantic_version: 25.0.5`; the `semantic_version` input is unchanged.

## Verification
- `pnpm build` (tsc) clean
- `pnpm test` — all 8 offline tests pass
- All three workflow YAML files validated

Lands as a `chore` → patch `rc` on merge to `main`.
