### PR TITLE
fix(client): only strip the /api prefix for hosted api*.sentio.xyz origins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,9 +47,11 @@ approval in `pnpm-workspace.yaml` (`allowBuilds: esbuild`).
   `openapi.json`). The generated descriptors carry the gateway's `/api/v1/...`
   annotation paths, so `createSentioTransport` wraps `fetch` to drop the leading
   `/api` segment before the request goes out (every public binding is
-  `/api/v1/*`). The legacy `https://app.sentio.xyz` origin served the
-  `/api/v1/...` paths verbatim and is being deprecated; pointing `baseUrl` at it
-  no longer routes, since the client now emits `/v1/...`.
+  `/api/v1/*`). The strip is applied only for the hosted `api*.sentio.xyz`
+  origins (and a relative `baseUrl`, assumed to proxy them); any other origin —
+  e.g. a grpc-gateway server reached directly — gets the annotated
+  `/api/v1/...` paths verbatim, and the `stripApiPrefix` option forces either
+  behavior explicitly.
 - protobuf-es conventions apply: request messages are partial init shapes
   (omitted fields take proto defaults), `oneof` fields are `{ case, value }`
   discriminated unions, errors are connect-es `ConnectError`s carrying the

--- a/src/client.ts
+++ b/src/client.ts
@@ -19,6 +19,16 @@ export interface SentioApiOptions extends Omit<GatewayTransportOptions, 'baseUrl
   apiKey?: string
   /** API origin; defaults to {@link DEFAULT_BASE_URL}. */
   baseUrl?: string
+  /**
+   * Force whether the leading `/api` segment is dropped from the generated
+   * `/api/v1/...` binding paths before a request is sent. Defaults to
+   * auto-detection by origin: stripped for the hosted `api*.sentio.xyz`
+   * origins (and for a relative `baseUrl`, assumed to proxy them), kept
+   * verbatim for any other origin — a grpc-gateway server routes the
+   * annotated `/api/v1/...` paths unchanged, and stripping there turns
+   * every call into an HTTP 404 (surfaced as Connect's `NotFound`).
+   */
+  stripApiPrefix?: boolean
 }
 
 /**
@@ -46,20 +56,38 @@ function stripGatewayPathPrefix(
 }
 
 /**
+ * Whether `baseUrl` points at a Sentio-hosted API origin (`api.sentio.xyz`
+ * and its environment variants like `api-test.sentio.xyz`), which serve the
+ * prefix-stripped `/v1/...` paths. A relative `baseUrl` counts as hosted —
+ * it is assumed to be a same-origin proxy of one of these hosts. Anything
+ * else (a grpc-gateway server on its own origin) serves the annotated
+ * `/api/v1/...` paths verbatim.
+ */
+function isHostedApiOrigin(baseUrl: string): boolean {
+  try {
+    const { hostname } = new URL(baseUrl)
+    return hostname.startsWith('api') && (hostname === 'api.sentio.xyz' || hostname.endsWith('.sentio.xyz'))
+  } catch {
+    return true
+  }
+}
+
+/**
  * Creates a Connect transport that speaks Sentio's REST (grpc-gateway)
  * dialect. Share one transport across clients of multiple services.
  */
 export function createSentioTransport(options: SentioApiOptions = {}): Transport {
-  const { apiKey, baseUrl, headers, fetch: customFetch, ...rest } = options
+  const { apiKey, baseUrl, headers, fetch: customFetch, stripApiPrefix, ...rest } = options
   const h = new Headers(headers)
   if (apiKey !== undefined && !h.has('api-key')) {
     h.set('api-key', apiKey)
   }
   const baseFetch = customFetch ?? globalThis.fetch
+  const strip = stripApiPrefix ?? isHostedApiOrigin(baseUrl ?? DEFAULT_BASE_URL)
   return createGatewayTransport({
     baseUrl: baseUrl ?? DEFAULT_BASE_URL,
     headers: h,
-    fetch: (input, init) => baseFetch(stripGatewayPathPrefix(input), init),
+    fetch: strip ? (input, init) => baseFetch(stripGatewayPathPrefix(input), init) : baseFetch,
     ...rest,
   })
 }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -88,6 +88,28 @@ test('listCoins routes to GET /v1/prices/coins (the /api prefix is stripped)', a
   assert.doesNotMatch(req.url, /\/api\/v1\//, 'the legacy /api prefix must not be sent')
 })
 
+test('hosted environment origins are also stripped', async () => {
+  const req = await callWith({ baseUrl: 'https://api-test.sentio.xyz' })
+  assert.equal(req.url, 'https://api-test.sentio.xyz/v1/prices/coins')
+})
+
+test('a non-hosted origin keeps the annotated /api/v1 path', async () => {
+  // A grpc-gateway server on its own origin routes the annotated
+  // /api/v1/... paths verbatim; stripping there would 404 every call.
+  const req = await callWith({ baseUrl: 'http://gateway.internal:10070' })
+  assert.equal(req.url, 'http://gateway.internal:10070/api/v1/prices/coins')
+})
+
+test('stripApiPrefix forces stripping on a non-hosted origin', async () => {
+  const req = await callWith({ baseUrl: 'https://proxy.example.com', stripApiPrefix: true })
+  assert.equal(req.url, 'https://proxy.example.com/v1/prices/coins')
+})
+
+test('stripApiPrefix: false keeps the annotated path on a hosted origin', async () => {
+  const req = await callWith({ stripApiPrefix: false })
+  assert.equal(req.url, 'https://api.sentio.xyz/api/v1/prices/coins')
+})
+
 test('one transport is shared across multiple service clients', async () => {
   const transport = createSentioTransport({ apiKey: 'shared' })
   const price = createClient(PriceService, transport)


### PR DESCRIPTION
## Problem

`createSentioTransport` unconditionally rewrites the generated `/api/v1/...` binding paths to `/v1/...`. That is correct for the hosted `api.sentio.xyz` origin (and its environment variants), but a grpc-gateway server reached directly on its own origin routes the **annotated** `/api/v1/...` paths verbatim. Pointing `baseUrl` at such a server makes every call hit a non-existent `/v1/...` route: the HTTP 404 is mapped to Connect's `NotFound`, which callers can easily mistake for a domain-level "not found" answer from the RPC itself (e.g. `@sentio/sdk`'s price util logs `price not found` and silently returns `undefined` for every coin).

## Fix

- Auto-detect by origin: strip for hosted `api*.sentio.xyz` origins and for a relative `baseUrl` (assumed to be a same-origin proxy of them); keep the annotated path for any other origin. As a side effect the legacy `app.sentio.xyz` origin, which serves `/api/v1/...` verbatim, routes again.
- Add a `stripApiPrefix` option to force either behavior explicitly (e.g. a custom domain proxying the hosted API).

## Testing

Added unit tests covering hosted/env origins, non-hosted origins, and both `stripApiPrefix` overrides; `pnpm build && pnpm test` passes (12 pass, 2 live-API tests skipped without key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)